### PR TITLE
Change clearvars parameter to make it run on Octave

### DIFF
--- a/main/gsrx.m
+++ b/main/gsrx.m
@@ -32,7 +32,7 @@ set(0,'defaultlinelinewidth',2);
 % Clean up the environment
 close all; 
 clc;
-clearvars -EXCEPT varargin
+clearvars -except varargin
 
 % Set number format
 format ('compact');


### PR DESCRIPTION
A small change to make GSRx to run on GNU Octave. I did a simple test with preprocessed GPS L1 test data and it seems to produce similar results on Octave and Matlab.